### PR TITLE
Follow sequelize naming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2987,6 +2987,11 @@
       "dev": true,
       "optional": true
     },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/EXIT-ALAMERY/next-auth-sequelize-adapter#readme",
   "dependencies": {
+    "uuid": "8.3.2",
     "core-js": "^3.11.0",
     "regenerator-runtime": "^0.13.7"
   },

--- a/src/adapter/index.js
+++ b/src/adapter/index.js
@@ -5,6 +5,10 @@ import { createHash, randomBytes } from "crypto";
 import { CreateUserError } from "./lib/errors";
 import logger from "./lib/logger";
 
+import { v4 as uuidv4 } from 'uuid';
+
+
+
 const Adapter = (config) => {
   const { models } = config;
 
@@ -38,9 +42,11 @@ const Adapter = (config) => {
 
     async function createUser(profile) {
       debug("CREATE_USER", profile);
+      console.log(profile, uuidv4());
 
       try {
         return models.User.create({
+          id: uuidv4(),
           name: profile.name,
           email: profile.email,
           image: profile.image,
@@ -148,6 +154,7 @@ const Adapter = (config) => {
       );
       try {
         return models.Account.create({
+          id: uuidv4(),
           accessToken,
           refreshToken,
           compoundId: getCompoundId(providerId, providerAccountId),
@@ -186,6 +193,7 @@ const Adapter = (config) => {
         }
 
         return models.Session.create({
+          id: uuidv4(),
           expires,
           userId: user.id,
           sessionToken: randomBytes(32).toString("hex"),
@@ -307,6 +315,7 @@ const Adapter = (config) => {
 
         // Save to database
         const verificationRequest = await models.VerificationRequest.create({
+          id: uuidv4(),
           identifier,
           token: hashedToken,
           expires,

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -34,6 +34,7 @@ export const accountModel = (Model, sequelize, Sequelize) => {
       },
     ],
   });
+  
 
   return Account;
 };

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -76,7 +76,6 @@ export const verificationRequestModel = (Model, sequelize, Sequelize) => {
   }
   VerificationRequest.init(verificationRequestSchema(Sequelize), {
     sequelize,
-    tableName: "verification_requests",
     modelName: "VerificationRequest",
   });
 

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -1,12 +1,18 @@
 "use strict";
 
 export const accountSchema = (DataTypes) => ({
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    allowNull: false,
+    primaryKey: true
+  },
   compoundId: {
     type: DataTypes.STRING,
     unique: true,
   },
   userId: {
-    type: DataTypes.INTEGER,
+    type: DataTypes.STRING,
   },
   providerType: {
     type: DataTypes.STRING,
@@ -35,8 +41,14 @@ export const accountSchema = (DataTypes) => ({
 });
 
 export const sessionSchema = (DataTypes) => ({
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    allowNull: false,
+    primaryKey: true
+  },
   userId: {
-    type: DataTypes.INTEGER,
+    type: DataTypes.STRING,
   },
   expires: {
     type: DataTypes.DATE,
@@ -58,6 +70,12 @@ export const sessionSchema = (DataTypes) => ({
 });
 
 export const userSchema = (DataTypes) => ({
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    allowNull: false,
+    primaryKey: true
+  },
   name: DataTypes.STRING,
   email: {
     type: DataTypes.STRING,
@@ -76,6 +94,12 @@ export const userSchema = (DataTypes) => ({
 });
 
 export const verificationRequestSchema = (DataTypes) => ({
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    allowNull: false,
+    primaryKey: true
+  },
   identitifer: DataTypes.STRING,
   token: {
     type: DataTypes.STRING,

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -3,72 +3,57 @@
 export const accountSchema = (DataTypes) => ({
   compoundId: {
     type: DataTypes.STRING,
-    field: "compound_id",
     unique: true,
   },
   userId: {
     type: DataTypes.INTEGER,
-    field: "user_id",
   },
   providerType: {
     type: DataTypes.STRING,
-    field: "provider_type",
   },
   providerId: {
     type: DataTypes.STRING,
-    field: "provider_id",
   },
   providerAccountId: {
     type: DataTypes.STRING,
-    field: "provider_account_id",
   },
   refreshToken: {
     type: DataTypes.STRING,
-    field: "refresh_token",
   },
   accessToken: {
     type: DataTypes.STRING,
-    field: "access_token",
   },
   accessTokenExpires: {
     type: DataTypes.DATE,
-    field: "access_token_expires",
   },
   createdAt: {
     type: DataTypes.DATE,
-    field: "created_at",
   },
   updatedAt: {
     type: DataTypes.DATE,
-    field: "updated_at",
   },
 });
 
 export const sessionSchema = (DataTypes) => ({
   userId: {
     type: DataTypes.INTEGER,
-    field: "user_id",
   },
   expires: {
     type: DataTypes.DATE,
   },
   sessionToken: {
     type: DataTypes.STRING,
-    field: "session_token",
     unique: true,
   },
   accessToken: {
     type: DataTypes.STRING,
-    field: "access_token",
     unique: true,
   },
   createdAt: {
     type: DataTypes.DATE,
-    field: "created_at",
   },
   updatedAt: {
     type: DataTypes.DATE,
-    field: "updated_at",
   },
 });
 
@@ -80,16 +65,13 @@ export const userSchema = (DataTypes) => ({
   },
   emailVerified: {
     type: DataTypes.DATE,
-    field: "email_verified",
   },
   image: DataTypes.STRING,
   createdAt: {
     type: DataTypes.DATE,
-    field: "created_at",
   },
   updatedAt: {
     type: DataTypes.DATE,
-    field: "updated_at",
   },
 });
 
@@ -102,10 +84,8 @@ export const verificationRequestSchema = (DataTypes) => ({
   expires: DataTypes.DATE,
   createdAt: {
     type: DataTypes.DATE,
-    field: "created_at",
   },
   updatedAt: {
     type: DataTypes.DATE,
-    field: "updated_at",
   },
 });


### PR DESCRIPTION
This PR makes the models follow the default naming strategies of sequelize.
It should still be possible to introduce your own overrides based on the logic described in the repository.

I also changed the IDs to UUID as numerical id's for sessions and users can be guessed.